### PR TITLE
added german translation (de-DE)

### DIFF
--- a/LEContextMenuHandler/Lang/de-DE.xml
+++ b/LEContextMenuHandler/Lang/de-DE.xml
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+
+<Strings>
+  <RunDefault>Mit Anwendungsprofil ausführen</RunDefault>
+  <Submenu>Locale Emulator</Submenu>
+  <ManageApp>Anwendungsprofil ändern</ManageApp>
+  <ManageAll>Globale Profilliste verwalten</ManageAll>
+</Strings>

--- a/LEGUI/Lang/de-DE.xaml
+++ b/LEGUI/Lang/de-DE.xaml
@@ -1,0 +1,23 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:system="clr-namespace:System;assembly=mscorlib">
+    <FontFamily x:Key="UIFont">Segoe UI</FontFamily>
+    <system:String x:Key="EnterArgument">Parameter (falls benötigt)</system:String>
+    <system:String x:Key="Save">Speichern</system:String>
+    <system:String x:Key="Cancel">Abbrechen</system:String>
+    <system:String x:Key="SaveAs">Speichern unter ...</system:String>
+    <system:String x:Key="SaveAsInstruction">Neuer Profilname:</system:String>
+    <system:String x:Key="Delete">Löschen</system:String>
+    <system:String x:Key="ConfirmDel">Möchten Sie dieses Profil wirklich löschen?</system:String>
+    <system:String x:Key="Location">Sprachumgebung</system:String>
+    <system:String x:Key="LocationSettings">Sprachumgebung</system:String>
+    <system:String x:Key="FontSettings">Schriftart</system:String>
+    <system:String x:Key="DefaultFont">Standardschriftart</system:String>
+    <system:String x:Key="TimezoneSettings">Zeitzone</system:String>
+    <system:String x:Key="Timezone">Zeitzone</system:String>
+    <system:String x:Key="DebugOptions">Debug (Erweitert)</system:String>
+    <system:String x:Key="WithCREATESUSPENDED">Prozess mit CREATE__SUSPENDED aufrufen</system:String>
+    <system:String x:Key="Miscellaneous">Sonstiges</system:String>
+    <system:String x:Key="ShowInMainMenu">Profil im Kontextmenü anzeigen</system:String>
+    <system:String x:Key="AskForShortcut">Möchten Sie eine Verknüpfung auf dem Desktop anlegen?</system:String>
+</ResourceDictionary>


### PR DESCRIPTION
I have added a german translation.
When copied into the folder of 1.0.7.5, it is displayed fine in the context menu, however legui does not use it. Maybe additional steps are needed.
