### PR TITLE
update fr locale to latest version

### DIFF
--- a/LEGUI/Lang/fr.xaml
+++ b/LEGUI/Lang/fr.xaml
@@ -17,7 +17,7 @@
     <system:String x:Key="DebugOptions">Options avancées</system:String>
     <system:String x:Key="AsAdmin">Exécuter en tant qu'administrateur</system:String>
     <system:String x:Key="RedirectRegistry">Registre faux</system:String>
-    <system:String x:Key="IsAdvancedRedirection">Faux système UI langue</system:String>
+    <system:String x:Key="IsAdvancedRedirection">Langue IU système fausse</system:String>
     <system:String x:Key="WithCREATESUSPENDED">Créer processus avec CREATE__SUSPENDED</system:String>
     <system:String x:Key="Miscellaneous">Divers</system:String>
     <system:String x:Key="ShowInMainMenu">Afficher ce profil dans le menu principal</system:String>


### PR DESCRIPTION
- update fr locale to latest version
- rename fr-FR to enable fallback for fr-* locale (fr-CA, fr-BE, etc.), same reason as #163 