### PR TITLE
update korean translation

### DIFF
--- a/LEContextMenuHandler/Lang/ko.xml
+++ b/LEContextMenuHandler/Lang/ko.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Strings>
   <RunDefault>애플리케이션 프로필로 실행</RunDefault>
-  <Submenu>로컬 에뮬레이터</Submenu>
+  <Submenu>로케일 에뮬레이터</Submenu>
   <ManageApp>애플리케이션 프로필 수정</ManageApp>
   <ManageAll>글로벌 프로필 목록을 편집</ManageAll>
 </Strings>


### PR DESCRIPTION
fix typo on korean pronunciation of locale.
로컬 is Local.
Locale should be 로케일.

Sorry to bother you..
and always thanks >_<