### PR TITLE
update README.md (#326)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ After you translated the above files into your language, please either create a 
 ## Build ##
 
  1. Clone the repo using Git.
- 2. Install Microsoft Visual Studio 2012 / 2013.
+ 2. Install Microsoft Visual Studio 2015 / 2017.
  3. Open `LocaleEmulator.sln`.
  4. Perform Build action.
 


### PR DESCRIPTION
Because of the use of string literal $"", Visual Studio 2013 and below is no longer supported.