### PR TITLE
Use correct German instead of Dutch

### DIFF
--- a/LEGUI/Lang/de.xaml
+++ b/LEGUI/Lang/de.xaml
@@ -6,7 +6,7 @@
     <system:String x:Key="Save">Speichern</system:String>
     <system:String x:Key="Shortcut">Verknüpfung anlegen</system:String>
     <system:String x:Key="Cancel">Abbrechen</system:String>
-    <system:String x:Key="SaveAs">Speichern unter ...</system:String>
+    <system:String x:Key="SaveAs">Speichern unter...</system:String>
     <system:String x:Key="SaveAsInstruction">Neuer Profilname:</system:String>
     <system:String x:Key="Delete">Löschen</system:String>
     <system:String x:Key="ConfirmDel">Möchten Sie dieses Profil wirklich löschen?</system:String>
@@ -16,8 +16,8 @@
     <system:String x:Key="Timezone">Zeitzone</system:String>
     <system:String x:Key="DebugOptions">Erweitert</system:String>
     <system:String x:Key="AsAdmin">Als Administrator ausführen</system:String>
-    <system:String x:Key="RedirectRegistry">Fake register</system:String>
-    <system:String x:Key="IsAdvancedRedirection">Fake systeem UI taal</system:String>
+    <system:String x:Key="RedirectRegistry">Registrierungseinträge vortäuschen</system:String>
+    <system:String x:Key="IsAdvancedRedirection">System-UI Sprache vortäuschen</system:String>
     <system:String x:Key="WithCREATESUSPENDED">Prozess mit CREATE__SUSPENDED aufrufen</system:String>
     <system:String x:Key="Miscellaneous">Sonstiges</system:String>
     <system:String x:Key="ShowInMainMenu">Profil im Kontextmenü anzeigen</system:String>


### PR DESCRIPTION
RedirectRegistry and IsAdvancedRedirection had a dutch translation instead of german.
Changed to the according translation from the English default, also removed the space after "Save as" as it does not fit on the button nicely otherwise.
(I am a native german)