### PR TITLE
English (US) as one of the default languages and some usage information in the readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ _ReSharper*/
 [Tt]est[Rr]esult*
 *.vssscc
 $tf*/
+/.vs
+/.vs/ProjectSettings.json
+/.vs/slnx.sqlite

--- a/LECommonLibrary/LEConfig.cs
+++ b/LECommonLibrary/LEConfig.cs
@@ -82,7 +82,18 @@ namespace LECommonLibrary
         {
             var defaultProfiles = new[]
                                   {
-                                      new LEProfile("Run in Japanese",
+                                      new LEProfile("Run in English (US)",
+                                                    Guid.NewGuid().ToString(),
+                                                    false,
+                                                    string.Empty,
+                                                    "en-US",
+                                                    "W. Europe Standard Time",
+                                                    false,
+                                                    true,
+                                                    false,
+                                                    false
+                                          ),
+                                       new LEProfile("Run in Japanese",
                                                     Guid.NewGuid().ToString(),
                                                     false,
                                                     string.Empty,

--- a/LEInstaller/Form1.Designer.cs
+++ b/LEInstaller/Form1.Designer.cs
@@ -32,10 +32,11 @@
             this.buttonInstall = new System.Windows.Forms.Button();
             this.buttonUninstall = new System.Windows.Forms.Button();
             this.buttonUninstallAllUsers = new System.Windows.Forms.Button();
-            this.buttonInstallAllUsers = new System.Windows.Forms.Button();
             this.label1 = new System.Windows.Forms.Label();
             this.groupBox1 = new System.Windows.Forms.GroupBox();
             this.groupBox2 = new System.Windows.Forms.GroupBox();
+            this.buttonInstallAllUsers = new System.Windows.Forms.Button();
+            this.buttonEditGlobal = new System.Windows.Forms.Button();
             this.groupBox1.SuspendLayout();
             this.groupBox2.SuspendLayout();
             this.SuspendLayout();
@@ -43,10 +44,9 @@
             // buttonInstall
             // 
             this.buttonInstall.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F);
-            this.buttonInstall.Location = new System.Drawing.Point(30, 33);
-            this.buttonInstall.Margin = new System.Windows.Forms.Padding(6);
+            this.buttonInstall.Location = new System.Drawing.Point(15, 17);
             this.buttonInstall.Name = "buttonInstall";
-            this.buttonInstall.Size = new System.Drawing.Size(329, 49);
+            this.buttonInstall.Size = new System.Drawing.Size(164, 25);
             this.buttonInstall.TabIndex = 0;
             this.buttonInstall.Text = "Install for current user";
             this.buttonInstall.UseVisualStyleBackColor = true;
@@ -55,10 +55,9 @@
             // buttonUninstall
             // 
             this.buttonUninstall.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F);
-            this.buttonUninstall.Location = new System.Drawing.Point(371, 33);
-            this.buttonUninstall.Margin = new System.Windows.Forms.Padding(6);
+            this.buttonUninstall.Location = new System.Drawing.Point(186, 17);
             this.buttonUninstall.Name = "buttonUninstall";
-            this.buttonUninstall.Size = new System.Drawing.Size(329, 49);
+            this.buttonUninstall.Size = new System.Drawing.Size(164, 25);
             this.buttonUninstall.TabIndex = 1;
             this.buttonUninstall.Text = "Uninstall for current user";
             this.buttonUninstall.UseVisualStyleBackColor = true;
@@ -67,33 +66,21 @@
             // buttonUninstallAllUsers
             // 
             this.buttonUninstallAllUsers.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F);
-            this.buttonUninstallAllUsers.Location = new System.Drawing.Point(371, 33);
-            this.buttonUninstallAllUsers.Margin = new System.Windows.Forms.Padding(6);
+            this.buttonUninstallAllUsers.Location = new System.Drawing.Point(186, 17);
             this.buttonUninstallAllUsers.Name = "buttonUninstallAllUsers";
-            this.buttonUninstallAllUsers.Size = new System.Drawing.Size(329, 49);
+            this.buttonUninstallAllUsers.Size = new System.Drawing.Size(164, 25);
             this.buttonUninstallAllUsers.TabIndex = 3;
             this.buttonUninstallAllUsers.Text = "Uninstall for all users";
             this.buttonUninstallAllUsers.UseVisualStyleBackColor = true;
             this.buttonUninstallAllUsers.Click += new System.EventHandler(this.buttonUninstallAllUsers_Click);
             // 
-            // buttonInstallAllUsers
-            // 
-            this.buttonInstallAllUsers.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F);
-            this.buttonInstallAllUsers.Location = new System.Drawing.Point(30, 33);
-            this.buttonInstallAllUsers.Margin = new System.Windows.Forms.Padding(6);
-            this.buttonInstallAllUsers.Name = "buttonInstallAllUsers";
-            this.buttonInstallAllUsers.Size = new System.Drawing.Size(329, 49);
-            this.buttonInstallAllUsers.TabIndex = 2;
-            this.buttonInstallAllUsers.Text = "Install for all users";
-            this.buttonInstallAllUsers.UseVisualStyleBackColor = true;
-            this.buttonInstallAllUsers.Click += new System.EventHandler(this.buttonInstallAllUsers_Click);
-            // 
             // label1
             // 
             this.label1.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F);
-            this.label1.Location = new System.Drawing.Point(15, 24);
+            this.label1.Location = new System.Drawing.Point(8, 12);
+            this.label1.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(726, 184);
+            this.label1.Size = new System.Drawing.Size(363, 125);
             this.label1.TabIndex = 4;
             this.label1.Text = resources.GetString("label1.Text");
             // 
@@ -102,9 +89,11 @@
             this.groupBox1.Controls.Add(this.buttonInstall);
             this.groupBox1.Controls.Add(this.buttonUninstall);
             this.groupBox1.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F);
-            this.groupBox1.Location = new System.Drawing.Point(12, 206);
+            this.groupBox1.Location = new System.Drawing.Point(7, 139);
+            this.groupBox1.Margin = new System.Windows.Forms.Padding(2);
             this.groupBox1.Name = "groupBox1";
-            this.groupBox1.Size = new System.Drawing.Size(729, 100);
+            this.groupBox1.Padding = new System.Windows.Forms.Padding(2);
+            this.groupBox1.Size = new System.Drawing.Size(364, 52);
             this.groupBox1.TabIndex = 5;
             this.groupBox1.TabStop = false;
             this.groupBox1.Text = "For currect user";
@@ -114,24 +103,49 @@
             this.groupBox2.Controls.Add(this.buttonInstallAllUsers);
             this.groupBox2.Controls.Add(this.buttonUninstallAllUsers);
             this.groupBox2.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F);
-            this.groupBox2.Location = new System.Drawing.Point(12, 330);
+            this.groupBox2.Location = new System.Drawing.Point(7, 204);
+            this.groupBox2.Margin = new System.Windows.Forms.Padding(2);
             this.groupBox2.Name = "groupBox2";
-            this.groupBox2.Size = new System.Drawing.Size(729, 100);
+            this.groupBox2.Padding = new System.Windows.Forms.Padding(2);
+            this.groupBox2.Size = new System.Drawing.Size(364, 52);
             this.groupBox2.TabIndex = 6;
             this.groupBox2.TabStop = false;
             this.groupBox2.Text = "For all users (requires admin)";
             // 
+            // buttonInstallAllUsers
+            // 
+            this.buttonInstallAllUsers.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F);
+            this.buttonInstallAllUsers.Location = new System.Drawing.Point(15, 17);
+            this.buttonInstallAllUsers.Name = "buttonInstallAllUsers";
+            this.buttonInstallAllUsers.Size = new System.Drawing.Size(164, 25);
+            this.buttonInstallAllUsers.TabIndex = 2;
+            this.buttonInstallAllUsers.Text = "Install for all users";
+            this.buttonInstallAllUsers.UseVisualStyleBackColor = true;
+            this.buttonInstallAllUsers.Click += new System.EventHandler(this.buttonInstallAllUsers_Click);
+            // 
+            // buttonEditGlobal
+            // 
+            this.buttonEditGlobal.Enabled = false;
+            this.buttonEditGlobal.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F);
+            this.buttonEditGlobal.Location = new System.Drawing.Point(22, 261);
+            this.buttonEditGlobal.Name = "buttonEditGlobal";
+            this.buttonEditGlobal.Size = new System.Drawing.Size(335, 25);
+            this.buttonEditGlobal.TabIndex = 4;
+            this.buttonEditGlobal.Text = "Edit global profile list";
+            this.buttonEditGlobal.UseVisualStyleBackColor = true;
+            this.buttonEditGlobal.Click += new System.EventHandler(this.buttonEditGlobal_Click);
+            // 
             // Form1
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(12F, 25F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.BackColor = System.Drawing.SystemColors.Window;
-            this.ClientSize = new System.Drawing.Size(753, 446);
+            this.ClientSize = new System.Drawing.Size(376, 291);
+            this.Controls.Add(this.buttonEditGlobal);
             this.Controls.Add(this.groupBox2);
             this.Controls.Add(this.groupBox1);
             this.Controls.Add(this.label1);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
-            this.Margin = new System.Windows.Forms.Padding(6);
             this.MaximizeBox = false;
             this.MinimizeBox = false;
             this.Name = "Form1";
@@ -150,10 +164,11 @@
         private System.Windows.Forms.Button buttonInstall;
         private System.Windows.Forms.Button buttonUninstall;
         private System.Windows.Forms.Button buttonUninstallAllUsers;
-        private System.Windows.Forms.Button buttonInstallAllUsers;
         private System.Windows.Forms.Label label1;
         private System.Windows.Forms.GroupBox groupBox1;
         private System.Windows.Forms.GroupBox groupBox2;
+        private System.Windows.Forms.Button buttonInstallAllUsers;
+        private System.Windows.Forms.Button buttonEditGlobal;
     }
 }
 

--- a/LEInstaller/Form1.cs
+++ b/LEInstaller/Form1.cs
@@ -58,7 +58,7 @@ namespace LEInstaller
 
             buttonUninstall.Enabled = ShellExtensionManager.IsInstalled(false);
             buttonUninstallAllUsers.Enabled = ShellExtensionManager.IsInstalled(true);
-            buttonEditGlobal.Enabled = ShellExtensionManager.IsInstalled(true);
+            buttonEditGlobal.Enabled = ShellExtensionManager.IsInstalled(true) || ShellExtensionManager.IsInstalled(false);
         }
 
         private void buttonInstall_Click(object sender, EventArgs e)
@@ -107,7 +107,7 @@ namespace LEInstaller
 
         private void buttonEditGlobal_Click(object sender, EventArgs e)
         {
-            Process.Start(Application.StartupPath + @"\LEGUI.exe");
+            Process.Start(Path.Combine(crtDir, "LEGUI.exe"));
             Application.Exit();
         }
 

--- a/LEInstaller/Form1.cs
+++ b/LEInstaller/Form1.cs
@@ -58,6 +58,7 @@ namespace LEInstaller
 
             buttonUninstall.Enabled = ShellExtensionManager.IsInstalled(false);
             buttonUninstallAllUsers.Enabled = ShellExtensionManager.IsInstalled(true);
+            buttonEditGlobal.Enabled = ShellExtensionManager.IsInstalled(true);
         }
 
         private void buttonInstall_Click(object sender, EventArgs e)
@@ -74,6 +75,7 @@ namespace LEInstaller
                 MessageBoxIcon.Information);
 
             buttonUninstall.Enabled = true;
+            buttonEditGlobal.Enabled = true;
         }
 
         private void buttonInstallAllUsers_Click(object sender, EventArgs e)
@@ -100,6 +102,13 @@ namespace LEInstaller
                 MessageBoxIcon.Information);
 
             buttonUninstallAllUsers.Enabled = true;
+            buttonEditGlobal.Enabled = true;
+        }
+
+        private void buttonEditGlobal_Click(object sender, EventArgs e)
+        {
+            Process.Start(Application.StartupPath + @"\LEGUI.exe");
+            Application.Exit();
         }
 
         public static void DisableDPIScale()

--- a/LEInstaller/Form1.resx
+++ b/LEInstaller/Form1.resx
@@ -123,6 +123,7 @@
 Begin by selecting either installation mode below.
  * For current user: Register context menu for current user only.
  * For all users: Register context menu for all users on this PC. This installation requires administrator privilege.
-</value>
+
+Afterwards, edit the languages and timezones available and advanced settings by using the global profile list.</value>
   </data>
 </root>

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ For usage, please read <http://xupefei.github.io/Locale-Emulator/> (in English a
 
 **LEGUI**       : Settings tool to edit the global profile list, languages and timezones to emulate etc
 
-**LEProc **     : Command line utility
+**LEProc**     : Command line utility
 
 **LEUpdater**   : Updater
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ Locale Emulator
 [![Github All Releases](https://img.shields.io/github/downloads/xupefei/Locale-Emulator/total.svg)](https://github.com/xupefei/Locale-Emulator/releases)
 [![GitHub release](https://img.shields.io/github/release/xupefei/Locale-Emulator.svg)](https://github.com/xupefei/Locale-Emulator/releases/latest)
 
-Yet Another System Region and Language Simulator
+Yet Another System Region and Language Simulator by xupefei and contributors
+Just a fork with English (US) as one of the default languages.
 
 ![LE interface](http://i.imgur.com/E4Gqyly.png)
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@ Locale Emulator
 
 Yet Another System Region and Language Simulator by xupefei and contributors.
 
-Just a fork with English (US) as one of the default languages.
-
 ![LE interface](http://i.imgur.com/E4Gqyly.png)
 
 ## Download ##

--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ Download available at <https://github.com/xupefei/Locale-Emulator/releases>.
 
 For usage, please read <http://xupefei.github.io/Locale-Emulator/> (in English and 中文).
 
+## Usage ##
+
+LEInstaller : Mandatory to open first for installation of Locale Emulator
+LEGUI       : Settings tool to edit the global profile list, languages and timezones to emulate etc
+LEProc      : Command line utility
+LEUpdater   : Updater
+
 ## Translate ##
 
 If you want to help translating Locale Emulator, you can find all strings in

--- a/README.md
+++ b/README.md
@@ -20,10 +20,13 @@ For usage, please read <http://xupefei.github.io/Locale-Emulator/> (in English a
 
 ## Usage ##
 
-LEInstaller : Mandatory to open first for installation of Locale Emulator
-LEGUI       : Settings tool to edit the global profile list, languages and timezones to emulate etc
-LEProc      : Command line utility
-LEUpdater   : Updater
+**LEInstaller** : Mandatory to open first for installation of Locale Emulator
+
+**LEGUI**       : Settings tool to edit the global profile list, languages and timezones to emulate etc
+
+**LEProc **     : Command line utility
+
+**LEUpdater**   : Updater
 
 ## Translate ##
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ For usage, please read <http://xupefei.github.io/Locale-Emulator/> (in English a
 
 ## Usage ##
 
-- **LEInstaller**: Mandatory to open first for installation of Locale Emulator
+- **LEInstaller**: Mandatory to open first for the installation of Locale Emulator
 - **LEGUI**: Settings tool to edit the global profile list, languages and timezones to emulate etc
 - **LEProc**: Command line utility
 - **LEUpdater**: Updater

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ Locale Emulator
 [![Github All Releases](https://img.shields.io/github/downloads/xupefei/Locale-Emulator/total.svg)](https://github.com/xupefei/Locale-Emulator/releases)
 [![GitHub release](https://img.shields.io/github/release/xupefei/Locale-Emulator.svg)](https://github.com/xupefei/Locale-Emulator/releases/latest)
 
-Yet Another System Region and Language Simulator by xupefei and contributors
+Yet Another System Region and Language Simulator by xupefei and contributors.
+
 Just a fork with English (US) as one of the default languages.
 
 ![LE interface](http://i.imgur.com/E4Gqyly.png)

--- a/README.md
+++ b/README.md
@@ -20,13 +20,10 @@ For usage, please read <http://xupefei.github.io/Locale-Emulator/> (in English a
 
 ## Usage ##
 
-**LEInstaller** : Mandatory to open first for installation of Locale Emulator
-
-**LEGUI**       : Settings tool to edit the global profile list, languages and timezones to emulate etc
-
-**LEProc**     : Command line utility
-
-**LEUpdater**   : Updater
+- **LEInstaller**: Mandatory to open first for installation of Locale Emulator
+- **LEGUI**: Settings tool to edit the global profile list, languages and timezones to emulate etc
+- **LEProc**: Command line utility
+- **LEUpdater**: Updater
 
 ## Translate ##
 


### PR DESCRIPTION
Hi, this is a really useful tool for me since game developers ever so often don't add languages options to their games (I used this for "The Walking Dead Michonne" btw). I was a bit surprise to find Japanese as the default language available after install since I imagine more people would use a tool like this to run software in English. So I just created this really basic pull request.

I also added some usage information in the readme so it's a bit easier to understand what which file does.

Also a button to open up the "edit global profile list tool" from the installer that pops up after successful installation would be nice for an intuitive installation, but I don't have VS installed currently to implement that.

This is my first github pull request, so I don't know how to cherry pick my commits, sorry. Exclude 	2d0cc17 and fadc9fc.

Edit: I implemented the edit global profile list button now and fixed the timezone on the English (US) language.

Edit2: Just an improvement idea: Multi-language support for the LEInstaller would be nice to implement.