### PR TITLE
Fix file handle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ _ReSharper*/
 [Tt]est[Rr]esult*
 *.vssscc
 $tf*/
+.vs/

--- a/LECommonLibrary/PEFileReader.cs
+++ b/LECommonLibrary/PEFileReader.cs
@@ -16,15 +16,15 @@ namespace LECommonLibrary
         {
             if (string.IsNullOrEmpty(path))
                 return PEType.Unknown;
+            var br = new BinaryReader(new FileStream(path,
+                    FileMode.Open,
+                    FileAccess.Read,
+                    FileShare.ReadWrite
+                ));
 
             try
             {
-                var br =
-                    new BinaryReader(new FileStream(path,
-                                                    FileMode.Open,
-                                                    FileAccess.Read,
-                                                    FileShare.ReadWrite
-                                         ));
+
 
                 //The following if clauses are meant to fix non-win32 executables with .exe extension
                 //other possible fixes:
@@ -35,23 +35,43 @@ namespace LECommonLibrary
                 //    the file is actually a dll or so with the same bytes)
                 //PS: I don't know why the file handle doen't close after both the stream and
                 //    the binary reader moves out of scope...
-
+                //PPS: For some reasons, the following code leaves the file handle open
+                //     if i+4<0 when compiled here, but closes the handle when run seperatedly
+                //     Code is changed to verifying the first two bytes...
+                /*
+                                //fix file handle doesn't close if file is empty
+                                if (br.BaseStream.Length < 0x3c) {
+                                    br.Close();
+                                    return PEType.Unknown;
+                                }
+                                br.BaseStream.Seek(0x3C, SeekOrigin.Begin);
+                                //fix file handle doen't close if file is not truly an WIN32 executable
+                                //the "br.ReadInt32()" here may lead to "br.ReadUInt16()" reading after the whole file
+                                //or even read before the file...
+                                Int32 i = br.ReadInt32();
+                                if (br.BaseStream.Length < i + 4 + sizeof(UInt16) || i + 4 < 0)
+                                {
+                                    br.Close();
+                                    return PEType.Unknown;
+                                }
+                */
+/*
+                //for some reason, following code still does not work here
                 //fix file handle doesn't close if file is empty
-                if (br.BaseStream.Length < 0x3c) {
-                    br.Close();
-                    return PEType.Unknown;
-                }
-                br.BaseStream.Seek(0x3C, SeekOrigin.Begin);
-                //fix file handle doen't close if file is not truly an WIN32 executable
-                //the "br.ReadInt32()" here may lead to "br.ReadUInt16()" reading after the whole file
-				//or even read before the file...
-				Int32 i = br.ReadInt32();
-                if (br.BaseStream.Length < i + 4 + sizeof(UInt16) || i + 4 < 0)
+                if (br.BaseStream.Length < 0x3c)
                 {
                     br.Close();
                     return PEType.Unknown;
                 }
-                br.BaseStream.Seek(i + 4, SeekOrigin.Begin);
+                //see if it is a WIN32 app
+                if (br.ReadInt16() != 0x4D5A)
+                {
+                    br.Close();
+                    return PEType.Unknown;
+                }
+*/
+                br.BaseStream.Seek(0x3C, SeekOrigin.Begin);
+                br.BaseStream.Seek(br.ReadInt32() + 4, SeekOrigin.Begin);
                 var machine = br.ReadUInt16();
 
                 br.Close();
@@ -66,6 +86,7 @@ namespace LECommonLibrary
             }
             catch
             {
+                br.Close();
                 return PEType.Unknown;
             }
         }

--- a/LECommonLibrary/PEFileReader.cs
+++ b/LECommonLibrary/PEFileReader.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 
 namespace LECommonLibrary
 {
@@ -44,7 +45,7 @@ namespace LECommonLibrary
                 //fix file handle doen't close if file is not truly an WIN32 executable
                 //the "br.ReadInt32()" here may lead to "br.ReadUInt16()" reading after the whole file
 
-                if (br.BaseStream.Length < sizeof(int) + 4)
+                if (br.BaseStream.Length < sizeof(Int32) + 4)
                 {
                     br.Close();
                     return PEType.Unknown;

--- a/LECommonLibrary/PEFileReader.cs
+++ b/LECommonLibrary/PEFileReader.cs
@@ -45,7 +45,7 @@ namespace LECommonLibrary
                 //fix file handle doen't close if file is not truly an WIN32 executable
                 //the "br.ReadInt32()" here may lead to "br.ReadUInt16()" reading after the whole file
 
-                if (br.BaseStream.Length < sizeof(Int32) + 4 && br.ReadInt32()+4>=0)
+                if (br.BaseStream.Length < sizeof(Int32) + 4 || br.ReadInt32()+4>=0)
                 {
                     br.Close();
                     return PEType.Unknown;

--- a/LECommonLibrary/PEFileReader.cs
+++ b/LECommonLibrary/PEFileReader.cs
@@ -45,7 +45,7 @@ namespace LECommonLibrary
                 //fix file handle doen't close if file is not truly an WIN32 executable
                 //the "br.ReadInt32()" here may lead to "br.ReadUInt16()" reading after the whole file
 
-                if (br.BaseStream.Length < sizeof(Int32) + 4)
+                if (br.BaseStream.Length < sizeof(Int32) + 4 && br.ReadInt32()+4>=0)
                 {
                     br.Close();
                     return PEType.Unknown;

--- a/LECommonLibrary/PEFileReader.cs
+++ b/LECommonLibrary/PEFileReader.cs
@@ -44,13 +44,14 @@ namespace LECommonLibrary
                 br.BaseStream.Seek(0x3C, SeekOrigin.Begin);
                 //fix file handle doen't close if file is not truly an WIN32 executable
                 //the "br.ReadInt32()" here may lead to "br.ReadUInt16()" reading after the whole file
-
-                if (br.BaseStream.Length < sizeof(Int32) + 4 || br.ReadInt32()+4<0)
+				//or even read before the file...
+				Int32 i = br.ReadInt32();
+                if (br.BaseStream.Length < i + 4 + sizeof(UInt16) || i + 4 < 0)
                 {
                     br.Close();
                     return PEType.Unknown;
                 }
-                br.BaseStream.Seek(br.ReadInt32() + 4, SeekOrigin.Begin);
+                br.BaseStream.Seek(i + 4, SeekOrigin.Begin);
                 var machine = br.ReadUInt16();
 
                 br.Close();

--- a/LECommonLibrary/PEFileReader.cs
+++ b/LECommonLibrary/PEFileReader.cs
@@ -25,7 +25,29 @@ namespace LECommonLibrary
                                                     FileShare.ReadWrite
                                          ));
 
+                //The following if clauses are meant to fix non-win32 executables with .exe extension
+                //other possible fixes:
+                //1. move BinaryReader br outside the try block and call br.close() in catch
+                //   (proposed by oroginal author, but I was afraid of creating br throwing execptions)
+                //2. add a line for verifying the first two bytes of the .exe to be "MZ" or 0x4D5A
+                //   (This may be a better solution, but I'm not sure if things will go fine if
+                //    the file is actually a dll or so with the same bytes)
+                //PS: I don't know why the file handle doen't close after both the stream and
+                //    the binary reader moves out of scope 
+
+                //fix file handle doesn't close if file is empty
+                if (br.BaseStream.Length < 0x3c) {
+                    br.Close();
+                    return PEType.Unknown;
+                }
                 br.BaseStream.Seek(0x3C, SeekOrigin.Begin);
+                //fix file handle doen't close if file is not truly an WIN32 executable
+                //the "br.ReadInt32()" here may lead to "br.ReadUInt16()" reading after the whole file
+                if (br.BaseStream.Length < br.ReadInt32() + 4)
+                {
+                    br.Close();
+                    return PEType.Unknown;
+                }
                 br.BaseStream.Seek(br.ReadInt32() + 4, SeekOrigin.Begin);
                 var machine = br.ReadUInt16();
 

--- a/LECommonLibrary/PEFileReader.cs
+++ b/LECommonLibrary/PEFileReader.cs
@@ -28,12 +28,12 @@ namespace LECommonLibrary
                 //The following if clauses are meant to fix non-win32 executables with .exe extension
                 //other possible fixes:
                 //1. move BinaryReader br outside the try block and call br.close() in catch
-                //   (proposed by oroginal author, but I was afraid of creating br throwing execptions)
+                //   (proposed by original author, but I was afraid of creating br throwing execptions)
                 //2. add a line for verifying the first two bytes of the .exe to be "MZ" or 0x4D5A
                 //   (This may be a better solution, but I'm not sure if things will go fine if
                 //    the file is actually a dll or so with the same bytes)
                 //PS: I don't know why the file handle doen't close after both the stream and
-                //    the binary reader moves out of scope 
+                //    the binary reader moves out of scope...
 
                 //fix file handle doesn't close if file is empty
                 if (br.BaseStream.Length < 0x3c) {

--- a/LECommonLibrary/PEFileReader.cs
+++ b/LECommonLibrary/PEFileReader.cs
@@ -43,7 +43,8 @@ namespace LECommonLibrary
                 br.BaseStream.Seek(0x3C, SeekOrigin.Begin);
                 //fix file handle doen't close if file is not truly an WIN32 executable
                 //the "br.ReadInt32()" here may lead to "br.ReadUInt16()" reading after the whole file
-                if (br.BaseStream.Length < br.ReadInt32() + 4)
+
+                if (br.BaseStream.Length < sizeof(int) + 4)
                 {
                     br.Close();
                     return PEType.Unknown;

--- a/LECommonLibrary/PEFileReader.cs
+++ b/LECommonLibrary/PEFileReader.cs
@@ -45,7 +45,7 @@ namespace LECommonLibrary
                 //fix file handle doen't close if file is not truly an WIN32 executable
                 //the "br.ReadInt32()" here may lead to "br.ReadUInt16()" reading after the whole file
 
-                if (br.BaseStream.Length < sizeof(Int32) + 4 || br.ReadInt32()+4>=0)
+                if (br.BaseStream.Length < sizeof(Int32) + 4 || br.ReadInt32()+4<0)
                 {
                     br.Close();
                     return PEType.Unknown;

--- a/LECommonLibrary/PEFileReader.cs
+++ b/LECommonLibrary/PEFileReader.cs
@@ -16,77 +16,83 @@ namespace LECommonLibrary
         {
             if (string.IsNullOrEmpty(path))
                 return PEType.Unknown;
-            var br = new BinaryReader(new FileStream(path,
+
+            //The following if clauses are meant to fix non-win32 executables with .exe extension
+            //Possible fixes:
+            //1. move BinaryReader br outside the try block and call br.close() in catch
+            //   (proposed by original author, but I was afraid of creating br throwing execptions)
+            //2. Veryfy the range every time the binary reader reads anything
+            //   (The most direct fix)
+            //3. add a line for verifying the first two bytes of the .exe to be "MZ" or 0x4D5A
+            //   (This may be a better solution, but I'm not sure if things will go fine if
+            //    the file is actually a dll or so with the same bytes)
+            //PS: I don't know why the file handle doen't close after both the stream and
+            //    the binary reader moves out of scope...
+            //PPS:Following code verifies the first two bytes, moved the reader to a outside try block
+            //    and made sure that the range is correct (all three methods)
+            try
+            {
+
+                var br = new BinaryReader(new FileStream(path,
                     FileMode.Open,
                     FileAccess.Read,
                     FileShare.ReadWrite
                 ));
 
-            try
-            {
+                try
+                {
+                    //fix file handle doesn't close if file is empty
+                    if (br.BaseStream.Length < 0x3c)
+                    {
+                        br.Close();
+                        return PEType.Unknown;
+                    }
 
+                    //see if it is a WIN32 app
+                    if (br.ReadInt16() != 0x4D5A)
+                    {
+                        br.Close();
+                        return PEType.Unknown;
+                    }
 
-                //The following if clauses are meant to fix non-win32 executables with .exe extension
-                //other possible fixes:
-                //1. move BinaryReader br outside the try block and call br.close() in catch
-                //   (proposed by original author, but I was afraid of creating br throwing execptions)
-                //2. add a line for verifying the first two bytes of the .exe to be "MZ" or 0x4D5A
-                //   (This may be a better solution, but I'm not sure if things will go fine if
-                //    the file is actually a dll or so with the same bytes)
-                //PS: I don't know why the file handle doen't close after both the stream and
-                //    the binary reader moves out of scope...
-                //PPS: For some reasons, the following code leaves the file handle open
-                //     if i+4<0 when compiled here, but closes the handle when run seperatedly
-                //     Code is changed to verifying the first two bytes...
-                /*
-                                //fix file handle doesn't close if file is empty
-                                if (br.BaseStream.Length < 0x3c) {
-                                    br.Close();
-                                    return PEType.Unknown;
-                                }
-                                br.BaseStream.Seek(0x3C, SeekOrigin.Begin);
-                                //fix file handle doen't close if file is not truly an WIN32 executable
-                                //the "br.ReadInt32()" here may lead to "br.ReadUInt16()" reading after the whole file
-                                //or even read before the file...
-                                Int32 i = br.ReadInt32();
-                                if (br.BaseStream.Length < i + 4 + sizeof(UInt16) || i + 4 < 0)
-                                {
-                                    br.Close();
-                                    return PEType.Unknown;
-                                }
-                */
-/*
-                //for some reason, following code still does not work here
-                //fix file handle doesn't close if file is empty
-                if (br.BaseStream.Length < 0x3c)
+                    br.BaseStream.Seek(0x3C, SeekOrigin.Begin);
+                    Int32 i = br.ReadInt32();
+
+                    //make sure that the read range is not outside the stream
+                    //useful if the file starts with 4D5A accidentally
+                    //(e.g. ansi text files starting with "MZ" without BOM heading with ".exe" extension)
+                    if (i + 4 + sizeof(UInt16) >= br.BaseStream.Length || i + 4 < 0)
+                    {
+                        br.Close();
+                        return PEType.Unknown;
+                    }
+
+                    br.BaseStream.Seek(i + 4, SeekOrigin.Begin);
+                    var machine = br.ReadUInt16();
+
+                    br.Close();
+
+                    if (machine == 0x014C)
+                        return PEType.X32;
+
+                    if (machine == 0x8664)
+                        return PEType.X64;
+
+                    return PEType.Unknown;
+                }
+                catch
                 {
                     br.Close();
                     return PEType.Unknown;
                 }
-                //see if it is a WIN32 app
-                if (br.ReadInt16() != 0x4D5A)
+                finally
                 {
-                    br.Close();
-                    return PEType.Unknown;
+                    br.Dispose();
                 }
-*/
-                br.BaseStream.Seek(0x3C, SeekOrigin.Begin);
-                br.BaseStream.Seek(br.ReadInt32() + 4, SeekOrigin.Begin);
-                var machine = br.ReadUInt16();
-
-                br.Close();
-
-                if (machine == 0x014C)
-                    return PEType.X32;
-
-                if (machine == 0x8664)
-                    return PEType.X64;
-
-                return PEType.Unknown;
             }
             catch
             {
-                br.Close();
+                //method to deal with error in starting to read
                 return PEType.Unknown;
             }
         }


### PR DESCRIPTION
Fixed a problem where file handle does not close after right clicking file with ".exe" extension, but is not WIN32 executable by verifying the length before reading from bytes to see the target structure.

Other possible solutions also proposed.

Thanks for a lot of help from @xupefei  by locating the problem.

